### PR TITLE
Allow emitting JavaDoc in decompiled files with an IFabricJavadocProvider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ compileJava {
 group = 'org.jetbrains'
 archivesBaseName = 'intellij-fernflower'
 
-version = '1.0.0'
+version = '1.1.0'
 
 def ENV = System.getenv()
 if (ENV.BUILD_NUMBER) {

--- a/src/net/fabricmc/fernflower/api/IFabricJavadocProvider.java
+++ b/src/net/fabricmc/fernflower/api/IFabricJavadocProvider.java
@@ -1,0 +1,30 @@
+package net.fabricmc.fernflower.api;
+
+import org.jetbrains.java.decompiler.struct.StructClass;
+import org.jetbrains.java.decompiler.struct.StructField;
+import org.jetbrains.java.decompiler.struct.StructMethod;
+
+import java.util.Map;
+
+/**
+ * Provides (optional) javadoc for Classes/Methods/Fields encountered by
+ *  {@link org.jetbrains.java.decompiler.main.ClassWriter}.
+ *
+ * May be set as a property in the constructor of {@link org.jetbrains.java.decompiler.main.Fernflower} by using
+ *  the key {@code IFabricJavadocProvider.PROPERTY_NAME}
+ */
+public interface IFabricJavadocProvider {
+  String PROPERTY_NAME = "fabric:javadoc";
+
+  default Iterable<String> getClassDoc(StructClass structClass) {
+    return null;
+  }
+
+  default Iterable<String> getFieldDoc(StructClass structClass, StructField structField) {
+    return null;
+  }
+
+  default Iterable<String> getMethodDoc(StructClass structClass, StructMethod structMethod) {
+    return null;
+  }
+}


### PR DESCRIPTION
Based entirely on the work of @modmuss50 - with minor edits to how exactly the JavaDoc provide object is injected into FF, to make the patch slightly smaller.