### PR TITLE
Don't add "D" literal when decompiling double

### DIFF
--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
@@ -207,15 +207,15 @@ public class ConstExprent extends Exprent {
           }
         }
         else if (Double.isNaN(doubleVal)) {
-          return new TextBuffer("0.0D / 0.0");
+          return new TextBuffer("0.0 / 0.0");
         }
         else if (doubleVal == Double.POSITIVE_INFINITY) {
-          return new TextBuffer("1.0D / 0.0");
+          return new TextBuffer("1.0 / 0.0");
         }
         else if (doubleVal == Double.NEGATIVE_INFINITY) {
-          return new TextBuffer("-1.0D / 0.0");
+          return new TextBuffer("-1.0 / 0.0");
         }
-        return new TextBuffer(value.toString()).append('D');
+        return new TextBuffer(value.toString());
 
       case CodeConstants.TYPE_NULL:
         return new TextBuffer("null");

--- a/testData/obfuscated/ag.java
+++ b/testData/obfuscated/ag.java
@@ -11,13 +11,13 @@ public class ag {
    public double a() {
       try {
          if (this.d == 0) {
-            return 0.0D;
+            return 0.0;
          }
       } catch (a_ var4) {
          throw var4;
       }
 
-      double var1 = 0.0D;
+      double var1 = 0.0;
 
       for(int var3 = 0; var3 <= this.d; ++var3) {
          var1 += (double)this.b[var3];

--- a/testData/obfuscated/aj.java
+++ b/testData/obfuscated/aj.java
@@ -106,7 +106,7 @@ public class aj implements am {
                Long var7 = (Long)this.b.get(var6.getKey());
                if (var7 != null) {
                   double var8 = (double)(((Long)var6.getValue() - var7) * 10L) / (double)var3;
-                  var1.a((Object)(new ar(h[1], (String)var6.getKey(), "%", var8 * 100.0D)));
+                  var1.a((Object)(new ar(h[1], (String)var6.getKey(), "%", var8 * 100.0)));
                }
             }
          }

--- a/testData/obfuscated/al.java
+++ b/testData/obfuscated/al.java
@@ -8,9 +8,9 @@ public class al implements Comparable<al> {
    private final ak a;
    private final List<n<Date, Double>> b = new ArrayList();
    private final List<n<Date, Double>> c = new ArrayList();
-   private double d = 0.0D;
-   private double e = 0.0D;
-   private double f = 0.0D;
+   private double d = 0.0;
+   private double e = 0.0;
+   private double f = 0.0;
    private static final String[] g;
 
    public al(ak var1) {
@@ -52,7 +52,7 @@ public class al implements Comparable<al> {
    public double e() {
       try {
          if (this.b.isEmpty()) {
-            return 0.0D;
+            return 0.0;
          }
       } catch (a_ var1) {
          throw var1;
@@ -64,7 +64,7 @@ public class al implements Comparable<al> {
    public double f() {
       try {
          if (this.c.isEmpty()) {
-            return 0.0D;
+            return 0.0;
          }
       } catch (a_ var1) {
          throw var1;

--- a/testData/obfuscated/at.java
+++ b/testData/obfuscated/at.java
@@ -8,7 +8,7 @@ class at extends ap {
    }
 
    public double d() {
-      return (double)an.a(this.d).getHeapMemoryUsage().getUsed() / 1024.0D / 1024.0D;
+      return (double)an.a(this.d).getHeapMemoryUsage().getUsed() / 1024.0 / 1024.0;
    }
 
    public String c() {
@@ -16,7 +16,7 @@ class at extends ap {
    }
 
    public Double e() {
-      return (double)an.a(this.d).getHeapMemoryUsage().getMax() / 1024.0D / 1024.0D;
+      return (double)an.a(this.d).getHeapMemoryUsage().getMax() / 1024.0 / 1024.0;
    }
 
    static {

--- a/testData/obfuscated/au.java
+++ b/testData/obfuscated/au.java
@@ -19,6 +19,6 @@ class au extends ap {
    }
 
    public Double e() {
-      return 100.0D;
+      return 100.0;
    }
 }

--- a/testData/obfuscated/av.java
+++ b/testData/obfuscated/av.java
@@ -19,6 +19,6 @@ class av extends ap {
    }
 
    public Double e() {
-      return 100.0D;
+      return 100.0;
    }
 }

--- a/testData/obfuscated/ax.java
+++ b/testData/obfuscated/ax.java
@@ -25,7 +25,7 @@ public class ax {
    }
 
    public String a(boolean var1) {
-      String var2 = String.valueOf(((double)System.nanoTime() - (double)this.a) / 1000.0D);
+      String var2 = String.valueOf(((double)System.nanoTime() - (double)this.a) / 1000.0);
 
       try {
          if (var1) {

--- a/testData/obfuscated/e.java
+++ b/testData/obfuscated/e.java
@@ -67,7 +67,7 @@ class e<K, V> implements a<K, V> {
          throw var5;
       }
 
-      var10000 = Math.round(100.0D * (double)var1 / (double)(var1 + var3));
+      var10000 = Math.round(100.0 * (double)var1 / (double)(var1 + var3));
       return var10000;
    }
 

--- a/testData/results/MoreAnnotations.dec
+++ b/testData/results/MoreAnnotations.dec
@@ -5,7 +5,7 @@ public @interface MoreAnnotations {
       intValue = 1,
       byteValue = 1,
       floatValue = 1.0F,
-      doubleValue = 1.0D,
+      doubleValue = 1.0,
       booleanValue = true,
       shortValue = 1,
       longValue = 1L,
@@ -35,7 +35,7 @@ public @interface MoreAnnotations {
       intArray = {1, 0, 2147483647, -2147483648},
       byteArray = {1, 0, 127, -128, -1},
       floatArray = {1.0F, 0.0F, 3.4028235E38F, 1.4E-45F, 0.0F / 0.0, 1.0F / 0.0, -1.0F / 0.0},
-      doubleArray = {1.0D, 0.0D, 1.7976931348623157E308D, 4.9E-324D, 0.0D / 0.0, 1.0D / 0.0, -1.0D / 0.0},
+      doubleArray = {1.0, 0.0, 1.7976931348623157E308, 4.9E-324, 0.0 / 0.0, 1.0 / 0.0, -1.0 / 0.0},
       booleanArray = {true, false},
       shortArray = {1, 0, 32767, -32768, -1},
       longArray = {1L, 0L, 9223372036854775807L, -9223372036854775808L},
@@ -53,7 +53,7 @@ public @interface MoreAnnotations {
 
    float floatValue() default 1.0F / 0.0;
 
-   double doubleValue() default 0.0D / 0.0;
+   double doubleValue() default 0.0 / 0.0;
 
    boolean booleanValue() default true;
 
@@ -77,7 +77,7 @@ public @interface MoreAnnotations {
 
    float[] floatArray() default {1.0F, 0.0F, 3.4028235E38F, 1.4E-45F, 0.0F / 0.0, 1.0F / 0.0, -1.0F / 0.0};
 
-   double[] doubleArray() default {1.0D, 0.0D, 1.7976931348623157E308D, 4.9E-324D, 0.0D / 0.0, 1.0D / 0.0, -1.0D / 0.0};
+   double[] doubleArray() default {1.0, 0.0, 1.7976931348623157E308, 4.9E-324, 0.0 / 0.0, 1.0 / 0.0, -1.0 / 0.0};
 
    boolean[] booleanArray() default {true, false};
 

--- a/testData/results/TestClassLoop.dec
+++ b/testData/results/TestClassLoop.dec
@@ -8,7 +8,7 @@ public class TestClassLoop {
    }
 
    public static void testFinally() {
-      boolean var0 = Math.random() > 0.0D;// 29
+      boolean var0 = Math.random() > 0.0;// 29
 
       while(true) {
          try {
@@ -22,7 +22,7 @@ public class TestClassLoop {
    }
 
    public static void testFinallyContinue() {
-      boolean var0 = Math.random() > 0.0D;// 45
+      boolean var0 = Math.random() > 0.0;// 45
 
       while(true) {
          while(true) {

--- a/testData/results/TestClassSimpleBytecodeMapping.dec
+++ b/testData/results/TestClassSimpleBytecodeMapping.dec
@@ -9,7 +9,7 @@ public class TestClassSimpleBytecodeMapping {
          }// 18
       });
       this.test2("1");// 21
-      if (Math.random() > 0.0D) {// 23
+      if (Math.random() > 0.0) {// 23
          System.out.println("0");// 24
          return 0;// 25
       } else {

--- a/testData/results/TestClassVar.dec
+++ b/testData/results/TestClassVar.dec
@@ -1,7 +1,7 @@
 package pkg;
 
 public class TestClassVar {
-   private boolean field_boolean = Math.random() > 0.0D;
+   private boolean field_boolean = Math.random() > 0.0;
    public int field_int = 0;
 
    public void testFieldSSAU() {

--- a/testData/results/TestConstants.dec
+++ b/testData/results/TestConstants.dec
@@ -21,11 +21,11 @@ public class TestConstants {
    static final float FPos = 1.0F / 0.0;
    static final float FMin = 1.4E-45F;
    static final float FMax = 3.4028235E38F;
-   static final double DNan = 0.0D / 0.0;
-   static final double DNeg = -1.0D / 0.0;
-   static final double DPos = 1.0D / 0.0;
-   static final double DMin = 4.9E-324D;
-   static final double DMax = 1.7976931348623157E308D;
+   static final double DNan = 0.0 / 0.0;
+   static final double DNeg = -1.0 / 0.0;
+   static final double DPos = 1.0 / 0.0;
+   static final double DMin = 4.9E-324;
+   static final double DMax = 1.7976931348623157E308;
 
    @TestConstants.A(byte.class)
    void m1() {

--- a/testData/results/TestIffSimplification.dec
+++ b/testData/results/TestIffSimplification.dec
@@ -22,7 +22,7 @@ public class TestIffSimplification {
          return mc1 < mc2 ? 1 : -1;// 35
       } else if (csg1 != csg2) {// 38
          return csg1 < csg2 ? 1 : -1;// 39
-      } else if (Math.abs(score1 - score2) < 1.0E-6D) {// 42
+      } else if (Math.abs(score1 - score2) < 1.0E-6) {// 42
          return doc1 < doc2 ? -1 : 1;// 43
       } else {
          return score1 < score2 ? 1 : -1;// 46

--- a/testData/results/TestPop2OneDoublePop2.dec
+++ b/testData/results/TestPop2OneDoublePop2.dec
@@ -2,7 +2,7 @@ package pkg;
 
 public class TestPop2OneDoublePop2 {
    public static void main(String... var0) {
-      double var10002 = 3.14159265358D;// 24
+      double var10002 = 3.14159265358;// 24
       System.out.println(1234567890);// 22 23 26
    }// 27
 }

--- a/testData/results/TestPrimitives.dec
+++ b/testData/results/TestPrimitives.dec
@@ -10,7 +10,7 @@ public class TestPrimitives {
       this.printInt(123);// 11
       this.printLong(123L);// 12
       this.printFloat(1.23F);// 13
-      this.printDouble(1.23D);// 14
+      this.printDouble(1.23);// 14
       this.printChar('Z');// 15
       this.printBooleanBoxed(true);// 17
       this.printByteBoxed((byte)123);// 18
@@ -19,7 +19,7 @@ public class TestPrimitives {
       this.printIntBoxed(40000);// 21
       this.printLongBoxed(123L);// 22
       this.printFloatBoxed(1.23F);// 23
-      this.printDoubleBoxed(1.23D);// 24
+      this.printDoubleBoxed(1.23);// 24
       this.printCharBoxed('Z');// 25
       this.printBoolean(Boolean.valueOf("true"));// 27
       this.printByte(Byte.valueOf("123"));// 28
@@ -33,8 +33,8 @@ public class TestPrimitives {
       this.printChar(this.getCharacter());// 37
       System.out.printf("%b, %d, %d, %d, %c, %d", true, 1, 213, 40000, 'c', 42L);// 39
       System.out.printf("%b, %d, %d, %d", this.getBoolean(), this.getByte(), this.getShort(), this.getInt());// 40
-      new TestPrimitives(false, (byte)123, (short)257, 40000, 123L, 3.14F, 1.618D, 'A');// 42
-      new TestPrimitives('A', 1.618D, 3.14F, 123L, 40000, (short)257, (byte)123, false);// 43
+      new TestPrimitives(false, (byte)123, (short)257, 40000, 123L, 3.14F, 1.618, 'A');// 42
+      new TestPrimitives('A', 1.618, 3.14F, 123L, 40000, (short)257, (byte)123, false);// 43
       new TestPrimitives(Boolean.valueOf("false"), Byte.valueOf("123"), Short.valueOf("257"), Integer.valueOf("40000"), Long.valueOf("123"), Float.valueOf("3.14"), Double.valueOf("1.618"), new Character('A'));// 44 45
    }// 46
 


### PR DESCRIPTION
Removes the D literal caused by decompiling doubles to improve code readability.